### PR TITLE
Update extension.ts to add comment with original sizes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,7 @@ export function generateClampFunction(baseFontSize: number, mobileFontSize: numb
   const vw = slope * 100;
 
   // Generate clamp string in rem
-  return `clamp(${mobileFontSizeRem}, calc(${formatRem(yAxisIntersection, baseFontSize)} + ${formatNumber(vw, 3)}vw), ${desktopFontSizeRem})`;
+  return `clamp(${mobileFontSizeRem}, calc(${formatRem(yAxisIntersection, baseFontSize)} + ${formatNumber(vw, 3)}vw), ${desktopFontSizeRem}); /* mobile: ${mobileFontSize}px, desktop: ${desktopFontSize}px */`;
 }
 
 export function deactivate() {}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -38,7 +38,7 @@ suite('Extension Test Suite', () => {
   describe('generateClampFunction', () => {
     it('should generate the correct clamp function string', () => {
       const result = generateClampFunction(16, 20, 16, 600, 1200);
-      assert.strictEqual(result, 'clamp(1rem, calc(0.821rem + 0.476vw), 1.25rem)'); // Check expected output
+      assert.strictEqual(result, 'clamp(1rem, calc(0.821rem + 0.476vw), 1.25rem); /* mobile: 16px, desktop: 20px */'); // Check expected output
     });
   });
 });


### PR DESCRIPTION
Thank you so much for this very helpful extension!

I was hoping I could propose one improvement. I think it'd be helpful to know what the target font sizes are in pixels since the clamp rem values might be hard to understand at a glance.